### PR TITLE
ci: remove unneeded packages for nri-discovery-kubernetes

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -16,21 +16,6 @@ env:
   TAG: ${{ github.event.release.tag_name }}
 
 jobs:
-  snyk:
-    name: Run security checks via snyk
-    runs-on: ubuntu-20.04
-    env:
-      SNYK_TOKEN: ${{ secrets.COREINT_SNYK_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
-          password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
-      - name: Scan code for vulnerabilities
-        run: make ci/snyk-test
-
   test-nix:
     name: Run unit tests on *Nix
     runs-on: ubuntu-20.04
@@ -69,7 +54,7 @@ jobs:
   prerelease:
     name: Build binary for *Nix/Win, create archives for *Nix/Win, create packages for *Nix, upload all artifacts into GH Release assets
     runs-on: ubuntu-20.04
-    needs: [test-nix, test-windows, snyk]
+    needs: [test-nix, test-windows]
     env:
       GPG_MAIL: 'infrastructure-eng@newrelic.com'
       GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}

--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -13,7 +13,6 @@ builds:
       - -s -w -X cmd.main.integrationVersion={{.Version}} -X cmd.main.gitCommit={{.Commit}}
     goos:
       - linux
-      - freebsd
       - darwin
     goarch:
       - 386
@@ -24,10 +23,6 @@ builds:
       - goos: darwin
         goarch: 386
       - goos: darwin
-        goarch: arm
-      - goos: freebsd
-        goarch: 386
-      - goos: freebsd
         goarch: arm
 
   - id: nri-discovery-kubernetes-win
@@ -41,36 +36,6 @@ builds:
       - amd64
     hooks:
       pre: build/windows/set_exe_properties.sh {{ .Env.TAG }} "discovery-kubernetes"
-
-nfpms:
-  - id: nri-discovery-kubernetes-pkg
-    builds:
-      - nri-discovery-kubernetes-nix
-    file_name_template: "{{ .ProjectName }}_{{ .Version }}-1_{{ .Arch }}"
-    vendor: "New Relic, Inc."
-    homepage: "https://www.newrelic.com/infrastructure"
-    maintainer: "New Relic Infrastructure Team <infrastructure-eng@newrelic.com>"
-    description: "Automatically discovers containers running inside Kubernetes"
-    license: "https://newrelic.com/terms (also see LICENSE installed with this package)"
-    # Formats to be generated.
-    formats:
-      - deb
-      - rpm
-    bindir: "/var/db/newrelic-infra/newrelic-integrations/bin"
-    contents:
-      - src: CHANGELOG.md
-        dst: /usr/share/doc/nri-discovery-kubernetes/CHANGELOG.md
-      - src: README.md
-        dst: /usr/share/doc/nri-discovery-kubernetes/README.md
-      - src: LICENSE
-        dst: /usr/share/doc/nri-discovery-kubernetes/LICENSE
-    dependencies:
-      - "newrelic-infra"
-    overrides:
-      rpm:
-        file_name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Arch }}"
-        replacements:
-          amd64: 1.x86_64
 
 archives:
   - id: nri-discovery-kubernetes-nix


### PR DESCRIPTION
`nri-discovery-kubernetes` is used only inside of docker files, and its pulled by the https://github.com/newrelic/infrastructure-bundle

Therefore there is no need to:

- build binaries for platforms for which we do not provide dockerfiles (e.g. bsd)
- generate rpm or deb packages