### PR TITLE
Pipeline refactor

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -6,6 +6,7 @@ on:
       - main
       - master
   pull_request:
+  workflow_dispatch:
 
 env:
   INTEGRATION: "discovery-kubernetes"
@@ -118,6 +119,10 @@ jobs:
       GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
     steps:
       - uses: actions/checkout@v3
-      - run: git tag "$TAG"
+      - run: |
+          git tag "$TAG"
+          if [ -z "$GPG_PASSPHRASE" ]; then
+            echo NO_SIGN=true >> $GITHUB_ENV
+          fi
       - name: Pre release
         run: make ci/fake-prerelease

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -8,9 +8,10 @@ on:
   pull_request:
 
 env:
-  TAG: "v0.0.0" # needed for goreleaser windows builds
+  INTEGRATION: "discovery-kubernetes"
+  ORIGINAL_REPO_NAME: 'newrelic/nri-discovery-kubernetes'
   REPO_FULL_NAME: ${{ github.event.repository.full_name }}
-  ORIGINAL_REPO_NAME: "newrelic/nri-discovery-kubernetes"
+  TAG: "v1.2.3" # needed for fake-prereleases
 
 jobs:
   static-analysis:
@@ -106,3 +107,17 @@ jobs:
           start args: "--container-runtime=${{ matrix.cri }}"
       - name: Run Integration Tests
         run: make test-integration
+
+  fake-prerelease:
+    name: Fakes the prerelease, making all the steps of a prerelease without uploading the assets to the Github release
+    runs-on: ubuntu-latest
+    needs: [test-nix, test-windows]
+    env:
+      GPG_MAIL: 'infrastructure-eng@newrelic.com'
+      GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+      GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
+    steps:
+      - uses: actions/checkout@v3
+      - run: git tag "$TAG"
+      - name: Pre release
+        run: make ci/fake-prerelease

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,5 +11,8 @@ RUN apt-get update \
         unzip \
         zip
 
+# Since the user does not match the owners of the repo "git rev-parse --is-inside-work-tree" fails and goreleaser does not populate projectName
+# https://stackoverflow.com/questions/72978485/git-submodule-update-failed-with-fatal-detected-dubious-ownership-in-repositor
+RUN git config --global --add safe.directory '*'
 RUN curl -L https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.deb -o gh_${GH_VERSION}_linux_amd64.deb
 RUN dpkg -i gh_${GH_VERSION}_linux_amd64.deb

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -81,6 +81,7 @@ ifdef TAG
 			-e INTEGRATION \
 			-e PRERELEASE=true \
 			-e NO_PUBLISH=true \
+			-e NO_SIGN \
 			-e GITHUB_TOKEN \
 			-e REPO_FULL_NAME \
 			-e TAG \

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -70,3 +70,25 @@ else
 	@echo "===> $(INTEGRATION) ===  [ci/prerelease] TAG env variable expected to be set"
 	exit 1
 endif
+
+.PHONY : ci/fake-prerelease
+ci/fake-prerelease: ci/deps
+ifdef TAG
+	@docker run --rm -t \
+			--name "nri-$(INTEGRATION)-prerelease" \
+			-v $(CURDIR):/go/src/github.com/newrelic/nri-$(INTEGRATION) \
+			-w /go/src/github.com/newrelic/nri-$(INTEGRATION) \
+			-e INTEGRATION \
+			-e PRERELEASE=true \
+			-e NO_PUBLISH=true \
+			-e GITHUB_TOKEN \
+			-e REPO_FULL_NAME \
+			-e TAG \
+			-e GPG_MAIL \
+			-e GPG_PASSPHRASE \
+			-e GPG_PRIVATE_KEY_BASE64 \
+			$(BUILDER_TAG) make release
+else
+	@echo "===> $(INTEGRATION) ===  [ci/prerelease] TAG env variable expected to be set"
+	exit 1
+endif

--- a/build/release.mk
+++ b/build/release.mk
@@ -34,14 +34,21 @@ endif
 
 .PHONY : release/sign/nix
 release/sign/nix:
+ifneq ($(NO_SIGN), true)
 	@echo "===> $(INTEGRATION) === [release/sign] signing packages"
 	@bash $(CURDIR)/build/nix/sign.sh
-
+else
+	@echo "===> $(INTEGRATION) === [release/sign] signing packages is disabled by environment variable"
+endif
 
 .PHONY : release/publish
 release/publish:
+ifneq ($(NO_PUBLISH), true)
 	@echo "===> $(INTEGRATION) === [release/publish] publishing artifacts"
 	@bash $(CURDIR)/build/upload_artifacts_gh.sh
+else
+	@echo "===> $(INTEGRATION) === [release/publish] publish is disabled by environment variable"
+endif
 
 .PHONY : release
 release: release/build release/sign/nix release/publish release/clean


### PR DESCRIPTION
Prerelease keeps failing:
![Screenshot 2023-03-14 at 16 41 28](https://user-images.githubusercontent.com/53659978/225055760-407b6320-1714-48f6-b36c-ce3312c0fa77.png)

So I created a target in the Makefile called `fake-prerelease` so we can test everything at PR time that is done in ar prerelease time.