### PR TITLE
URL changed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ and engaging with the security community are important means to achieve our
 security goals.  If you believe you have found a security vulnerability in this
 project or any of New Relic's products or websites, we welcome and greatly
 appreciate you reporting it to New Relic through
-[HackerOne](https://hackerone.com/newrelic).
+[our bug bounty program](https://docs.newrelic.com/docs/security/security-privacy/information-security/report-security-vulnerabilities/).
 
 ## Setting up your environment
 


### PR DESCRIPTION
We are changing our bug bounty provider from HackerOne to BugCrowd and so the URL and text needs adjustments.